### PR TITLE
Feature url check

### DIFF
--- a/services/ClamAvProtectionService.cfc
+++ b/services/ClamAvProtectionService.cfc
@@ -66,7 +66,7 @@ component {
 		var fileUploadFields = {};
 
 		for( var field in ListToArray( form.fieldNames ?: "" ) ) {
-			if ( isSimpleValue( form[ field ] ) && FileExists( form[ field ] ) ) {
+			if ( isSimpleValue( form[ field ] ) && !reFindNoCase('(http|https)://', form[ field ] ) && FileExists( form[ field ] ) ) {
 				fileUploadFields[ field ] = form[ field ];
 			}
 		}


### PR DESCRIPTION
Check that string does not contain http / https before processing FileExists, or it will throw illegal character error when attempting to interpret http/https URL as filepath