### PR TITLE
CLAMAV-6 Be more strict with looking in form fields for file uploads

### DIFF
--- a/services/ClamAvProtectionService.cfc
+++ b/services/ClamAvProtectionService.cfc
@@ -66,10 +66,13 @@ component {
 	}
 
 	private struct function _getFileUploadFields() {
-		var fileUploadFields = {};
+		var fileUploadDir             = GetTempDirectory();
+		var dirLen                    = Len( fileUploadDir );
+		var directoryTraversalPattern = "\.\.\\/"; // i.e. ../, or ..\
+		var fileUploadFields          = {};
 
 		for( var field in ListToArray( form.fieldNames ?: "" ) ) {
-			if ( isSimpleValue( form[ field ] ) && !reFindNoCase('(http|https)://', form[ field ] ) && FileExists( form[ field ] ) ) {
+			if ( IsSimpleValue( form[ field ] ) && Left( form[ field ], dirLen ) == fileUploadDir && !ReFind( directoryTraversalPattern, form[ field ] ) && FileExists( form[ field ] ) ) {
 				fileUploadFields[ field ] = form[ field ];
 			}
 		}


### PR DESCRIPTION
1. File should only belong in Lucee tmp directory
2. File path should not contain any directory traversal
    
This prevents scary looking errors being thrown in the scanner when an attacker makes a POST request with a param such as: `../../../etc/passwd`
    
This only errors when Lucee will expand that path and the path exists. The error is then a file not found when we try to pass that file using Java to our scanner (file not found, because we do not expand it). So it is not a vulnerability, just very scary looking.